### PR TITLE
Fix koala-replayer.so compile error

### DIFF
--- a/koala/build.sh
+++ b/koala/build.sh
@@ -3,11 +3,11 @@ set -e
 set -x
 
 RDEBUG=$(cd ../`dirname $0` && pwd -P)
+export GOPATH=/tmp/build-golang
 
 case $1 in
     "recorder" )
         # record to file, only for testing purpose
-        export GOPATH=/tmp/build-golang
         export CGO_CFLAGS="-DKOALA_LIBC_NETWORK_HOOK -DKOALA_LIBC_FILE_HOOK"
         export CGO_CPPFLAGS="-DKOALA_LIBC_NETWORK_HOOK -DKOALA_LIBC_FILE_HOOK"
         export CGO_CXXFLAGS="-std=c++11 -Wno-ignored-attributes"
@@ -18,7 +18,6 @@ case $1 in
             mkdir -p /tmp/build-golang/src/github.com/didi
             ln -s $RDEBUG /tmp/build-golang/src/github.com/didi/rdebug
         fi
-        export GOPATH=/tmp/build-golang
         if [ ! -f "$GOPATH/bin/glide" ]; then
             go get github.com/Masterminds/glide
         fi


### PR DESCRIPTION
When trying to compile koala base on "4.3 Compile Koala" in wiki, "cd koala; sh build.sh vendor; sh build.sh recorder" will run correctly with default "export GOPATH=/tmp/build-golang". But "sh build.sh" will fail becase lacking of this default GOPATH setting. 
Result in compile error like: https://github.com/didi/rdebug/issues/21